### PR TITLE
Add stub authentication and VIN binding

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,23 +1,28 @@
 import { Routes, Route } from 'react-router-dom';
 import Navbar from './components/Navbar/Navbar.jsx';
+import RequireAuth from './components/RequireAuth.jsx';
 import Dashboard from './pages/Dashboard/Dashboard.jsx';
 import Car from './pages/Car/Car.jsx';
 import Parts from './pages/Parts/Parts.jsx';
 import Expenses from './pages/Expenses/Expenses.jsx';
 import Settings from './pages/Settings/Settings.jsx';
 import AddMod from './pages/AddMod/AddMod.jsx';
+import Login from './pages/Login.jsx';
+import Register from './pages/Register.jsx';
 
 function App() {
   return (
     <div className="app">
       <div className="app__content">
         <Routes>
-          <Route path="/" element={<Dashboard />} />
-          <Route path="/car" element={<Car />} />
-          <Route path="/parts" element={<Parts />} />
-          <Route path="/expenses" element={<Expenses />} />
-          <Route path="/settings" element={<Settings />} />
-          <Route path="/add-mod" element={<AddMod />} />
+          <Route path="/login" element={<Login />} />
+          <Route path="/register" element={<Register />} />
+          <Route path="/" element={<RequireAuth><Dashboard /></RequireAuth>} />
+          <Route path="/car" element={<RequireAuth><Car /></RequireAuth>} />
+          <Route path="/parts" element={<RequireAuth><Parts /></RequireAuth>} />
+          <Route path="/expenses" element={<RequireAuth><Expenses /></RequireAuth>} />
+          <Route path="/settings" element={<RequireAuth><Settings /></RequireAuth>} />
+          <Route path="/add-mod" element={<RequireAuth><AddMod /></RequireAuth>} />
         </Routes>
       </div>
       <Navbar />

--- a/src/components/RequireAuth.jsx
+++ b/src/components/RequireAuth.jsx
@@ -1,0 +1,12 @@
+import { Navigate } from 'react-router-dom';
+import useAuth from '../hooks/useAuth.js';
+
+function RequireAuth({ children }) {
+  const { user } = useAuth();
+  if (!user) {
+    return <Navigate to="/login" replace />;
+  }
+  return children;
+}
+
+export default RequireAuth;

--- a/src/hooks/useAuth.js
+++ b/src/hooks/useAuth.js
@@ -1,0 +1,49 @@
+import { createContext, useContext, useState } from 'react';
+
+const AuthContext = createContext();
+
+export function AuthProvider({ children }) {
+  const [token, setToken] = useState(() => localStorage.getItem('token'));
+  const [user, setUser] = useState(() => {
+    const stored = localStorage.getItem('user');
+    return stored ? JSON.parse(stored) : null;
+  });
+
+  const delay = (ms) => new Promise((r) => setTimeout(r, ms));
+
+  const login = async (username) => {
+    await delay(500);
+    const data = { token: 'demo-token', user: { id: 1, username } };
+    setToken(data.token);
+    setUser(data.user);
+    localStorage.setItem('token', data.token);
+    localStorage.setItem('user', JSON.stringify(data.user));
+  };
+
+  const register = async (username) => {
+    await delay(500);
+    const data = { token: 'demo-token', user: { id: 1, username } };
+    setToken(data.token);
+    setUser(data.user);
+    localStorage.setItem('token', data.token);
+    localStorage.setItem('user', JSON.stringify(data.user));
+  };
+
+  const logout = () => {
+    setToken(null);
+    setUser(null);
+    localStorage.removeItem('token');
+    localStorage.removeItem('user');
+    localStorage.removeItem('carVin');
+  };
+
+  return (
+    <AuthContext.Provider value={{ user, token, login, register, logout, setUser }}>
+      {children}
+    </AuthContext.Provider>
+  );
+}
+
+export default function useAuth() {
+  return useContext(AuthContext);
+}

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -2,13 +2,16 @@ import { StrictMode } from 'react';
 import { createRoot } from 'react-dom/client';
 import { BrowserRouter } from 'react-router-dom';
 import App from './App.jsx';
+import { AuthProvider } from './hooks/useAuth.js';
 import './styles/global.css';
 import './sw-register.js';
 
 createRoot(document.getElementById('root')).render(
   <StrictMode>
     <BrowserRouter>
-      <App />
+      <AuthProvider>
+        <App />
+      </AuthProvider>
     </BrowserRouter>
   </StrictMode>
 );

--- a/src/pages/Car/Car.css
+++ b/src/pages/Car/Car.css
@@ -2,6 +2,35 @@
   padding: 1rem;
 }
 
+.vin-bind {
+  display: flex;
+  gap: 0.5rem;
+  margin-bottom: 1rem;
+}
+
+.vin-bind__input {
+  flex: 1;
+  padding: 0.5rem;
+  border: 1px solid #ccc;
+  border-radius: 0.25rem;
+}
+
+.vin-bind__button {
+  padding: 0.5rem 1rem;
+  background: var(--color-primary);
+  color: #fff;
+  border: none;
+  border-radius: 0.25rem;
+}
+
+.vin-card {
+  background: var(--card-bg);
+  padding: 1rem;
+  border-radius: 0.5rem;
+  box-shadow: 0 1px 4px rgba(0, 0, 0, 0.1);
+  margin-bottom: 1rem;
+}
+
 .car-form {
   display: grid;
   gap: 0.5rem;

--- a/src/pages/Car/Car.jsx
+++ b/src/pages/Car/Car.jsx
@@ -1,5 +1,6 @@
 import { useState } from "react";
 import { Link } from "react-router-dom";
+import useAuth from "../../hooks/useAuth.js";
 import {
   getCarInfo,
   saveCarInfo,
@@ -8,11 +9,22 @@ import {
 import "./Car.css";
 
 function Car() {
+  const { user, setUser } = useAuth();
   const initial = getCarInfo();
   const [vin, setVin] = useState(initial.vin || "");
   const [mileage, setMileage] = useState(initial.mileage || "");
   const [tab, setTab] = useState("mods");
+  const [bindVin, setBindVin] = useState("");
   const mods = getMods();
+
+  const handleBind = async (e) => {
+    e.preventDefault();
+    await new Promise((r) => setTimeout(r, 500));
+    const updated = { ...user, carVin: bindVin };
+    setUser(updated);
+    localStorage.setItem('carVin', bindVin);
+    localStorage.setItem('user', JSON.stringify(updated));
+  };
 
   const handleSubmit = (e) => {
     e.preventDefault();
@@ -23,6 +35,21 @@ function Car() {
   return (
     <div className="car-page">
       <h1>Моя машина</h1>
+      {!user?.carVin ? (
+        <form className="vin-bind" onSubmit={handleBind}>
+          <input
+            className="vin-bind__input"
+            value={bindVin}
+            onChange={(e) => setBindVin(e.target.value)}
+            placeholder="VIN"
+          />
+          <button className="vin-bind__button" type="submit">
+            Привязать машину
+          </button>
+        </form>
+      ) : (
+        <div className="vin-card">VIN: {user.carVin}</div>
+      )}
       <form className="car-form" onSubmit={handleSubmit}>
         <label className="car-form__label">
           VIN

--- a/src/pages/Dashboard/Dashboard.jsx
+++ b/src/pages/Dashboard/Dashboard.jsx
@@ -1,7 +1,6 @@
 import './Dashboard.css';
 import { useEffect, useState } from 'react';
 import CardStat from '../../components/CardStat/CardStat.jsx';
-import AdsPlaceholder from '../../components/AdsPlaceholder/AdsPlaceholder.jsx';
 import { getLastExpenses } from '../../hooks/useDB.js';
 
 function Dashboard() {
@@ -32,7 +31,6 @@ function Dashboard() {
           </button>
         </CardStat>
 
-        <AdsPlaceholder />
 
         <CardStat
           title="Расходы месяца"

--- a/src/pages/Login.css
+++ b/src/pages/Login.css
@@ -1,0 +1,28 @@
+.login-page {
+  padding: 1rem;
+}
+
+.login-form {
+  display: grid;
+  gap: 0.5rem;
+  margin-bottom: 1rem;
+}
+
+.login-form__input {
+  padding: 0.5rem;
+  border: 1px solid #ccc;
+  border-radius: 0.25rem;
+}
+
+.login-form__submit {
+  padding: 0.5rem 1rem;
+  background: var(--color-primary);
+  color: #fff;
+  border: none;
+  border-radius: 0.25rem;
+}
+
+.login__link {
+  color: var(--color-primary);
+  font-size: 0.875rem;
+}

--- a/src/pages/Login.jsx
+++ b/src/pages/Login.jsx
@@ -1,0 +1,46 @@
+import { useState } from 'react';
+import { useNavigate, Link } from 'react-router-dom';
+import useAuth from '../hooks/useAuth.js';
+import './Login.css';
+
+function Login() {
+  const navigate = useNavigate();
+  const { login } = useAuth();
+  const [username, setUsername] = useState('');
+  const [password, setPassword] = useState('');
+
+  const handleSubmit = async (e) => {
+    e.preventDefault();
+    await login(username, password);
+    navigate('/');
+  };
+
+  return (
+    <div className="login-page">
+      <h1>Вход</h1>
+      <form className="login-form" onSubmit={handleSubmit}>
+        <input
+          className="login-form__input"
+          value={username}
+          onChange={(e) => setUsername(e.target.value)}
+          placeholder="Username"
+        />
+        <input
+          className="login-form__input"
+          type="password"
+          value={password}
+          onChange={(e) => setPassword(e.target.value)}
+          placeholder="Password"
+        />
+        <button className="login-form__submit" type="submit">
+          Войти
+        </button>
+      </form>
+      <Link className="login__link" to="/register">
+        Регистрация
+      </Link>
+    </div>
+  );
+}
+
+export default Login;

--- a/src/pages/Parts/Parts.jsx
+++ b/src/pages/Parts/Parts.jsx
@@ -8,10 +8,26 @@ function Parts() {
   const [tab, setTab] = useState("all");
 
   useEffect(() => {
-    fetch("/data/parts.json")
-      .then((r) => r.json())
-      .then(setParts)
-      .catch(() => setParts([]));
+    const load = async () => {
+      await new Promise((r) => setTimeout(r, 500));
+      setParts([
+        {
+          id: 1,
+          name: "Масляный фильтр",
+          oem: "0001",
+          category: "Двигатель",
+          analogs: ["A1", "A2"],
+        },
+        {
+          id: 2,
+          name: "Тормозные колодки",
+          oem: "0002",
+          category: "Тормоза",
+          analogs: ["B1"],
+        },
+      ]);
+    };
+    load();
   }, []);
 
   const categories = ["Все", "Двигатель", "Тормоза", "Подвеска"];

--- a/src/pages/Register.css
+++ b/src/pages/Register.css
@@ -1,0 +1,28 @@
+.register-page {
+  padding: 1rem;
+}
+
+.register-form {
+  display: grid;
+  gap: 0.5rem;
+  margin-bottom: 1rem;
+}
+
+.register-form__input {
+  padding: 0.5rem;
+  border: 1px solid #ccc;
+  border-radius: 0.25rem;
+}
+
+.register-form__submit {
+  padding: 0.5rem 1rem;
+  background: var(--color-primary);
+  color: #fff;
+  border: none;
+  border-radius: 0.25rem;
+}
+
+.register__link {
+  color: var(--color-primary);
+  font-size: 0.875rem;
+}

--- a/src/pages/Register.jsx
+++ b/src/pages/Register.jsx
@@ -1,0 +1,46 @@
+import { useState } from 'react';
+import { useNavigate, Link } from 'react-router-dom';
+import useAuth from '../hooks/useAuth.js';
+import './Register.css';
+
+function Register() {
+  const navigate = useNavigate();
+  const { register } = useAuth();
+  const [username, setUsername] = useState('');
+  const [password, setPassword] = useState('');
+
+  const handleSubmit = async (e) => {
+    e.preventDefault();
+    await register(username, password);
+    navigate('/login');
+  };
+
+  return (
+    <div className="register-page">
+      <h1>Регистрация</h1>
+      <form className="register-form" onSubmit={handleSubmit}>
+        <input
+          className="register-form__input"
+          value={username}
+          onChange={(e) => setUsername(e.target.value)}
+          placeholder="Username"
+        />
+        <input
+          className="register-form__input"
+          type="password"
+          value={password}
+          onChange={(e) => setPassword(e.target.value)}
+          placeholder="Password"
+        />
+        <button className="register-form__submit" type="submit">
+          Создать аккаунт
+        </button>
+      </form>
+      <Link className="register__link" to="/login">
+        Уже есть аккаунт?
+      </Link>
+    </div>
+  );
+}
+
+export default Register;

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -91,3 +91,7 @@ body {
     padding-bottom: 4rem;
   }
 }
+
+.ads-placeholder {
+  display: none !important;
+}


### PR DESCRIPTION
## Summary
- implement `useAuth` context with localStorage persistence
- add login and register pages
- protect routes via new `RequireAuth` component
- wrap app with `AuthProvider`
- hide AdsPlaceholder component and disable markup
- stub data loading in Parts page
- add VIN binding section on car page
- hide ads globally

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_687762f3ebe88329bccdf833e8be6168